### PR TITLE
Fix movieDetailInfoTableVC inappropriation

### DIFF
--- a/boostcamp_3_iOS_BoxOffice/Boostcamp_3_iOS_BoxOffice/Controller/MovieDetailInfoTableVC.swift
+++ b/boostcamp_3_iOS_BoxOffice/Boostcamp_3_iOS_BoxOffice/Controller/MovieDetailInfoTableVC.swift
@@ -205,15 +205,7 @@ class MovieDetailInfoTableVC: UITableViewController, UIGestureRecognizerDelegate
             return UITableViewCell()
         }
         
-        guard let comments = self.comments else {
-            return UITableViewCell()
-        }
-        
-        if comments.count == 0 {
-            return UITableViewCell()
-        }
-        
-        let comment = comments[indexPath.row]
+
         
         switch indexPath.section {
         case 0:
@@ -248,6 +240,16 @@ class MovieDetailInfoTableVC: UITableViewController, UIGestureRecognizerDelegate
             
             return cell
         case 3:
+            guard let comments = self.comments else {
+                return UITableViewCell()
+            }
+            
+            if comments.count == 0 {
+                return UITableViewCell()
+            }
+            
+            let comment = comments[indexPath.row]
+            
             if indexPath.row == 0 {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: "firstCommentCell", for: indexPath) as? FirstCommentCell else {
                     return UITableViewCell()


### PR DESCRIPTION
코멘트가 없는 경우 디테일 테이블 뷰의 모든 셀이 UITableViewCell로 Return되어 문제가 될 수 있을 것 같습니다.
수정 사항은 cellForRowAt 메서드에서 Comment 데이터가 있는 지 체크하는 코드 블럭을 Case 3 분기점으로 이동한 내용입니다.